### PR TITLE
Example of using postcss config in separate file

### DIFF
--- a/config/postcss/postcss.config.js
+++ b/config/postcss/postcss.config.js
@@ -1,0 +1,20 @@
+module.exports = (ctx) => ({
+    'map': false,
+    'plugins': {
+        'postcss-import': {
+            root: ctx.file.dirname
+        },
+        'postcss-cssnext': {
+            'warnForDuplicates': false,
+            'features': {
+                'customProperties': {
+                    'preserve': true
+                },
+                'rem': false
+            }
+        },
+        'cssnano': {
+            preset: 'default'
+        }
+    }
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "start": "concurrently 'npm run jekyll:dev' 'npm run styles:dev' 'npm run scripts:dev'",
-    "styles:dev": "postcss src/stylesheets/main.css -o dist/assets/css/main.css -w",
+    "styles:dev": "postcss -w -c config/postcss/postcss.config.js src/stylesheets/main.css -o dist/assets/css/main.css",
     "scripts:dev": "rollup -c config/rollup/config.js -w",
     "jekyll:dev": "jekyll serve -c config/jekyll/config.yml",
     "styles:build": "postcss src/stylesheets/main.css -o src/jekyll/_includes/assets/main.css",
@@ -41,22 +41,6 @@
     "standard": "^10.0.2",
     "stylelint": "^8.0.0",
     "sw-precache": "^5.2.0"
-  },
-  "postcss": {
-    "map": false,
-    "plugins": {
-      "postcss-import": {},
-      "postcss-cssnext": {
-        "warnForDuplicates": false,
-        "features": {
-          "customProperties": {
-            "preserve": true
-          },
-          "rem": false
-        }
-      },
-      "cssnano": {}
-    }
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Shows how to put postcss config in a separate file.  Key is that you need to name it postcss.config.js